### PR TITLE
INTERLOK-3187 #comment Add repository and readme location to the pom …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,6 +206,8 @@ publishing {
         properties.appendNode("target", "3.6.6+")
         properties.appendNode("license", "false")
         properties.appendNode("tags", "ssh,management,tunnel")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-sshtunnel")
+        properties.appendNode("readme", "https://github.com/adaptris/interlok-sshtunnel/develop/README.md")
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -207,7 +207,7 @@ publishing {
         properties.appendNode("license", "false")
         properties.appendNode("tags", "ssh,management,tunnel")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-sshtunnel")
-        properties.appendNode("readme", "https://github.com/adaptris/interlok-sshtunnel/develop/README.md")
+        properties.appendNode("readme", "https://github.com/adaptris/interlok-sshtunnel/raw/develop/README.md")
       }
     }
   }


### PR DESCRIPTION
## Motivation

Give the UI the ability to point to the optional component repository

## Modification

Add two new properties into the pom file with the repository and the readme urls

## Result

The info will eventually be available in the UI(s)

## Testing

Check that the new repository property exist in the pom file after doing:
>gradle generatePomFileForMavenJavaPublication
